### PR TITLE
fix: avoid global scope styles

### DIFF
--- a/packages/vue3-marquee/src/vue3-marquee.vue
+++ b/packages/vue3-marquee/src/vue3-marquee.vue
@@ -229,7 +229,7 @@ export default defineComponent({
   animation-play-state: var(--pauseOnClick);
 }
 
-.marquee {
+.vue3-marquee > .marquee {
   flex: 0 0 auto;
   min-width: var(--min-width);
   z-index: 1;
@@ -249,20 +249,20 @@ export default defineComponent({
   }
 }
 
-.overlay {
+.vue3-marquee > .overlay {
   position: absolute;
   width: 100%;
   height: 100%;
 }
 
-.transparent-overlay {
+.vue3-marquee > .transparent-overlay {
   position: absolute;
   width: 100%;
   height: 100%;
 }
 
-.overlay::before,
-.overlay::after {
+.vue3-marquee > .overlay::before,
+.vue3-marquee > .overlay::after {
   background: linear-gradient(to right, var(--gradient-color));
   content: '';
   height: 100%;
@@ -271,13 +271,13 @@ export default defineComponent({
   z-index: 2;
 }
 
-.overlay::after {
+.vue3-marquee > .overlay::after {
   right: 0;
   top: 0;
   transform: rotateZ(180deg);
 }
 
-.overlay::before {
+.vue3-marquee > .overlay::before {
   left: 0;
   top: 0;
 }


### PR DESCRIPTION
The following styles are declared in the global scope which may conflict with the app using this component as they have quite 
generic names:
- `overlay`
- `marquee`
- `transparent-overlay`

I've forced them under the `vue3-marquee` scope to make sure they don't interfer with the global scope.