### PR TITLE
feat: add support for vertical marquees (fixes #15, #65, #78)

### DIFF
--- a/packages/playground/vite-project/src/App.vue
+++ b/packages/playground/vite-project/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <HelloWorld msg="Hello Vue 3 + TypeScript + Vite + Vue3 Marquee" />
+
     <div>
       <p>Default</p>
       <Vue3Marquee>
@@ -50,10 +51,24 @@
       </Vue3Marquee>
     </div>
     <div>
+      <p>Gradient Length: 600px</p>
+      <Vue3Marquee :gradient="true" gradient-length="600px">
+        <img v-for="i in img_30" :key="i" height="80" :src="i" />
+      </Vue3Marquee>
+    </div>
+    <div>
       <p>clone</p>
       <Vue3Marquee :clone="true" :duration="5">
         <img v-for="i in img_5" :key="i" height="80" :src="i" />
       </Vue3Marquee>
+    </div>
+    <div>
+      <p>Vertical</p>
+      <div style="height: 500px; width: max-content">
+        <Vue3Marquee :vertical="true">
+          <img v-for="i in img_30" :key="i" height="50" :src="i" />
+        </Vue3Marquee>
+      </div>
     </div>
     <div>
       <p>

--- a/packages/vue3-marquee/package.json
+++ b/packages/vue3-marquee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue3-marquee",
-  "version": "3.1.3",
+  "version": "3.2.0-beta.0",
   "license": "MIT",
   "description": "A simple marquee component with ZERO dependencies for Vue 3",
   "author": "Sanjay Soundarajan <info@sanjaysoundarajan.dev> (https://sanjaysoundarajan.dev)",


### PR DESCRIPTION
Finally got around to working on this. This PR allows for all props to be used in vertical marquees.

- Scroll `direction` goes up for `normal` or down for `reverse`
- `gradient` is fully functional in the vertical direction
- `gradientWidth` prop is being deprecated
- `gradientLength` will be the new replacement prop
- `clone` is also functional with respect to height

This library should be the only one required now for all marquees with Vue 3 or Nuxt 3.