### PR TITLE
feat!: fix types and css import for v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A simple marquee component with ZERO dependencies for Vue 3. This component was 
 
 View the live demos here: [https://vue3-marquee.vercel.app/examples](https://vue3-marquee.vercel.app/examples)
 
+## Upgrade to v4.x
+
+If you are using version 3.x of `vue3-marquee` you should upgrade to version 4.x. You can do this by running the [Installation and Usage](#installation-and-usage) command below. This add better support for Typescript. There is also a change with the `dist/style.css` import (it's been removed) so take a look at the [new documentation](https://vue3-marquee.vercel.app/introduction/v4) for instructions on how to migrate to this package.
+
 ## Installation and Usage
 
 ### Vue 3
@@ -32,7 +36,6 @@ The most common use case is to register the component globally.
 // main.js
 import { createApp } from 'vue'
 import Vue3Marquee from 'vue3-marquee'
-import 'vue3-marquee/dist/style.css'
 
 createApp(App).use(Vue3Marquee).mount('#app')
 ```
@@ -49,7 +52,6 @@ Alternatively you can also import the component locally.
 
 ```js
 import { Vue3Marquee } from 'vue3-marquee'
-import 'vue3-marquee/dist/style.css'
 
 export default {
   components: {
@@ -71,7 +73,6 @@ You can then use the component in your template
 
 <script>
 import { Vue3Marquee } from 'vue3-marquee'
-import 'vue3-marquee/dist/style.css'
 
 export default {
   components: {
@@ -108,12 +109,6 @@ export default defineNuxtPlugin((nuxtApp) => {
 ```
 
 This should register as a global component that you can call anywhere in your app under the `<Vue3Marquee>` tag.
-
-- Import the css file required by the component into your **`app.vue`** file.
-
-```js
-import 'vue3-marquee/dist/style.css'
-```
 
 ## Props and options
 

--- a/docs/components/content/CardsExample.vue
+++ b/docs/components/content/CardsExample.vue
@@ -11,7 +11,6 @@
 </template>
 
 <script setup>
-import 'vue3-marquee/dist/style.css'
 const avatarArray = reactive([])
 
 for (let i = 0; i < 5; i++) {

--- a/docs/components/content/CardsPauseOnHover.vue
+++ b/docs/components/content/CardsPauseOnHover.vue
@@ -12,8 +12,6 @@
 </template>
 
 <script setup>
-import 'vue3-marquee/dist/style.css'
-
 const avatarArray = reactive([])
 
 for (let i = 0; i < 5; i++) {

--- a/docs/components/content/CardsPauseOnHoverEmits.vue
+++ b/docs/components/content/CardsPauseOnHoverEmits.vue
@@ -17,8 +17,6 @@
 </template>
 
 <script setup>
-import 'vue3-marquee/dist/style.css'
-
 const avatarArray = reactive([])
 const playState = ref('playing')
 

--- a/docs/components/content/ImagesWithClone.vue
+++ b/docs/components/content/ImagesWithClone.vue
@@ -11,7 +11,6 @@
 </template>
 
 <script setup>
-import 'vue3-marquee/dist/style.css'
 const imgArray = [
   'https://sponsors.vuejs.org/images/layer0.avif',
   'https://sponsors.vuejs.org/images/plaid__inc_.svg',

--- a/docs/components/content/ImagesWithGradient.vue
+++ b/docs/components/content/ImagesWithGradient.vue
@@ -15,8 +15,6 @@
 </template>
 
 <script setup>
-import 'vue3-marquee/dist/style.css'
-
 const colorMode = useColorMode()
 
 const imgArray = [

--- a/docs/components/content/ImagesWithPauseOnClick.vue
+++ b/docs/components/content/ImagesWithPauseOnClick.vue
@@ -11,7 +11,6 @@
 </template>
 
 <script setup>
-import 'vue3-marquee/dist/style.css'
 const imgArray = [
   'https://sponsors.vuejs.org/images/vueschool.avif',
   'https://sponsors.vuejs.org/images/vehikl.avif',

--- a/docs/components/content/ImagesWithoutClone.vue
+++ b/docs/components/content/ImagesWithoutClone.vue
@@ -11,7 +11,6 @@
 </template>
 
 <script setup>
-import 'vue3-marquee/dist/style.css'
 const imgArray = [
   'https://sponsors.vuejs.org/images/layer0.avif',
   'https://sponsors.vuejs.org/images/plaid__inc_.svg',

--- a/docs/components/content/TextExample.vue
+++ b/docs/components/content/TextExample.vue
@@ -12,8 +12,6 @@
 </template>
 
 <script setup>
-import 'vue3-marquee/dist/style.css'
-
 const helloArray = [
   'hello',
   'こんにちは',

--- a/docs/components/content/VerticalMarquee.vue
+++ b/docs/components/content/VerticalMarquee.vue
@@ -13,8 +13,6 @@
 </template>
 
 <script setup>
-import 'vue3-marquee/dist/style.css'
-
 const colorMode = useColorMode()
 
 const imgArray = [

--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -62,6 +62,24 @@ What's included
   Only a single component with all the props you need.
   ::
 
- 
+  ::card{icon=mdi:compare-vertical}
+  #title
+  Vertical Marquee
+  #description
+  You can also create a vertical marquee with this component.
+  ::
 
+  ::card{icon=fa6-solid:clone}
+  #title
+  Cloning
+  #description
+  You can clone the children if there is not enough content to fill the marquee.
+  ::
+
+  ::card{icon=carbon:interactive-segmentation-cursor}
+  #title
+  Events
+  #description
+  Use mouse events for use as a carousel or slider alternative.
+  ::
 ::

--- a/docs/content/1.introduction/1.installation.md
+++ b/docs/content/1.introduction/1.installation.md
@@ -26,20 +26,8 @@ pnpm add vue3-marquee@latest
 
 ::
 
-## Import the CSS
-
-Import the required CSS file.
-
-::code-group
-
-```js [main.ts (Vue SPAs)]
-import 'vue3-marquee/dist/style.css'
-```
-
-```js [app.vue (Nuxt)]
-import 'vue3-marquee/dist/style.css'
-```
-
+::alert{type="warning"}
+If you upgrading from v3 to v4, please remove the `dist/style.css` import from your project. This css is now imported automatically by the plugin. For more information, see [Migrating from v3 to v4](/introduction/v4).
 ::
 
 ::alert{type="success"}

--- a/docs/content/1.introduction/2.vue-3.md
+++ b/docs/content/1.introduction/2.vue-3.md
@@ -1,5 +1,9 @@
 # Usage with Vue 3
 
+::alert{type="warning"}
+If you upgrading from v3 to v4, please remove the `dist/style.css` import from your main.js or main.ts file. This css is now imported automatically by the plugin.
+::
+
 ## Register the component
 
 The most common use case is to register the component globally.
@@ -8,8 +12,6 @@ The most common use case is to register the component globally.
 // main.js
 import { createApp } from 'vue'
 import Vue3Marquee from 'vue3-marquee'
-
-import 'vue3-marquee/dist/style.css'
 
 createApp(App).use(Vue3Marquee).mount('#app')
 ```
@@ -34,8 +36,6 @@ Alternatively you can also import the component locally in your SFC.
 ```js
 import { Vue3Marquee } from 'vue3-marquee'
 
-import 'vue3-marquee/dist/style.css'
-
 export default {
   components: {
     Vue3Marquee,
@@ -57,10 +57,6 @@ You can then use the component in your template as follows:
     <img height="200" width="300" src="...img" />
   </Vue3Marquee>
 </template>
-
-<script setup lang="ts">
-import 'vue3-marquee/dist/style.css'
-</script>
 ```
 
 ```vue [Composition API]
@@ -75,8 +71,6 @@ import 'vue3-marquee/dist/style.css'
 <script>
 import { defineComponent } from 'vue'
 import { Vue3Marquee } from 'vue3-marquee'
-
-import 'vue3-marquee/dist/style.css'
 
 export default defineComponent({
   components: {
@@ -100,8 +94,6 @@ export default defineComponent({
 
 <script>
 import { Vue3Marquee } from 'vue3-marquee'
-
-import 'vue3-marquee/dist/style.css'
 
 export default {
   components: {

--- a/docs/content/1.introduction/3.nuxt-3.md
+++ b/docs/content/1.introduction/3.nuxt-3.md
@@ -1,5 +1,9 @@
 # Usage with Nuxt 3
 
+::alert{type="warning"}
+If you upgrading from v3 to v4, please remove the `dist/style.css` import from your `app.vue` file. This css is now imported automatically by the plugin.
+::
+
 ## Register the component
 
 1. Create a folder called **`plugins`** at the root of your project.
@@ -14,22 +18,6 @@
    export default defineNuxtPlugin((nuxtApp) => {
      nuxtApp.vueApp.use(Vue3Marquee, { name: 'Vue3Marquee' })
    })
-   ```
-
-4. Import the css file required by the component into your **`app.vue`** file.
-
-   ```vue
-   <template>
-     <NuxtLayout>
-       <NuxtPage />
-     </NuxtLayout>
-   </template>
-
-   <script setup lang="ts">
-   import 'vue3-marquee/dist/style.css'
-
-   // ... rest of your code
-   </script>
    ```
 
    ::alert{type="success"}

--- a/docs/content/1.introduction/4.v4.md
+++ b/docs/content/1.introduction/4.v4.md
@@ -1,0 +1,46 @@
+# Migrating from v3 to v4
+
+The v4 release of `vue3-marquee` uses a new build flow with Vite and Esbuild. This new build flow allows better Typescript support. This also removes the need for the `dist/style.css` file. The css is now imported automatically by the library.
+
+Since making this change will break applications that are using the `dist/style.css` file, I have decided to release v4 as a new version of this package. This will allow users to upgrade to v4 at their own pace. v3 will not be receiving any new features or bug fixes.
+
+All the examples and documentation have been updated to use v4. If you are using v3, I recommend upgrading to v4 as soon as possible. It should be a very simple upgrade.
+
+## Upgrading to v4
+
+To upgrade to v4, you will need to uninstall the v3 package and install the v4 package.
+
+::code-group
+
+```bash [yarn]
+yarn remove vue3-marquee
+yarn add vue3-marquee@latest
+```
+
+```bash [npm]
+npm uninstall vue3-marquee
+npm install vue3-marquee@latest --save
+```
+
+```bash [pnpm]
+pnpm remove vue3-marquee
+pnpm add vue3-marquee@latest
+```
+
+::
+
+## Removing the `dist/style.css` file
+
+The `dist/style.css` file is no longer needed. You can remove it from your project. The css is now imported automatically by the library.
+
+### Vue 3
+
+If you are using Vue 3, you can remove the `dist/style.css` import from your `main.js` or `main.ts` file.
+
+### Nuxt 3
+
+If you are using Nuxt 3, you can remove the `dist/style.css` import from your `app.vue` file.
+
+::alert{type="success"}
+✨ Well done! You have successfully upgraded to v4.
+::

--- a/docs/content/3.examples.md
+++ b/docs/content/3.examples.md
@@ -212,7 +212,7 @@ With this component you can also create a vertical marquee. This is useful if yo
 **You will need to put your marquee inside a parent container with a defined height.**  You can also use a fixed width if you want to limit the width of the marquee. The marquee component will otherwise take up the full width of the parent container.
 
 ::alert{type="warning"}
-Vertical marquees are still experimental. All props and events are supported, but there may be some bugs. Please [open an issue](https://github.com/megasanjay/vue3-lottie/issues/new) if you find any.
+Vertical marquees are still experimental. All props and events are supported, but there may be some bugs. Please [open an issue](https://github.com/megasanjay/vue3-marquee/issues/new) if you find any.
 ::
 
 ::alert{type="success"}

--- a/docs/content/3.examples.md
+++ b/docs/content/3.examples.md
@@ -22,8 +22,6 @@ Some examples of how to use the library are shown below.
     </template>
 
     <script setup>
-    import 'vue3-marquee/dist/style.css'
-
     const helloArray = ['hello', 'こんにちは', 'bonjour', ...]
     </script>
     ```
@@ -49,8 +47,6 @@ Some examples of how to use the library are shown below.
     </template>
 
     <script setup>
-    import 'vue3-marquee/dist/style.css'
-
     const imgArray = [
         'https://sponsors.vuejs.org/images/vueschool.avif',
         'https://sponsors.vuejs.org/images/vehikl.avif',
@@ -83,8 +79,6 @@ Some examples of how to use the library are shown below.
     </template>
 
     <script setup>
-    import 'vue3-marquee/dist/style.css'
-
     const avatarArray = [
         'https://avatars.dicebear.com/api/avataaars/1.svg',
         'https://avatars.dicebear.com/api/avataaars/2.svg',
@@ -128,8 +122,6 @@ In this example the following props are used:
     </template>
 
     <script setup>
-    import 'vue3-marquee/dist/style.css'
-
     const colorMode = useColorMode()
 
     const imgArray = [
@@ -166,8 +158,6 @@ The marquee can pause when you hover over the content. This is useful if you wan
     </template>
 
     <script setup>
-    import 'vue3-marquee/dist/style.css'
-
     const avatarArray = [
         'https://avatars.dicebear.com/api/avataaars/1.svg',
         'https://avatars.dicebear.com/api/avataaars/2.svg',
@@ -204,8 +194,6 @@ If you need more functionality than this, using a carousel component might be be
     </template>
 
     <script setup>
-    import 'vue3-marquee/dist/style.css'
-
     const imgArray = [
         'https://sponsors.vuejs.org/images/vueschool.avif',
         'https://sponsors.vuejs.org/images/vehikl.avif',
@@ -250,9 +238,7 @@ All props (including `clone`) and events are supported for vertical marquees. Th
     </template>
 
     <script setup>
-    import 'vue3-marquee/dist/style.css'
-
-     const imgArray = [
+    const imgArray = [
         'https://sponsors.vuejs.org/images/vueschool.avif',
         'https://sponsors.vuejs.org/images/vehikl.avif',
         'https://sponsors.vuejs.org/images/dronahq.avif',
@@ -291,8 +277,6 @@ All props (including `clone`) and events are supported for vertical marquees. Th
     </template>
 
     <script setup>
-    import 'vue3-marquee/dist/style.css'
-    
     const playState = ref('playing')
 
     const avatarArray = [
@@ -337,8 +321,6 @@ This option is also responsive to the container width. If you resize the window,
     </template>
 
     <script setup>
-    import 'vue3-marquee/dist/style.css'
-
     const imgArray = [
         'https://sponsors.vuejs.org/images/layer0.avif',
         'https://sponsors.vuejs.org/images/plaid__inc_.svg',

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,6 +20,6 @@
   },
   "dependencies": {
     "vue3-lottie": "^2.7.1",
-    "vue3-marquee": "^3.2.1"
+    "vue3-marquee": "4.0.0-beta.0"
   }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -8225,10 +8225,10 @@ vue3-lottie@^2.7.1:
     lodash-es "^4.17.21"
     lottie-web "5.12.2"
 
-vue3-marquee@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/vue3-marquee/-/vue3-marquee-3.2.1.tgz#591cc35b3e953608c69e6d2a69804a8d26f907d0"
-  integrity sha512-pNvmdtF06cm6AD0fKiPCuH6W80z+WB4Lpfx5Zd+jHrZovyFRRJOgXBNqXQtiBA1jQWcsHR2QQ/8Eu4OFLFgX2Q==
+vue3-marquee@4.0.0-beta.0:
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/vue3-marquee/-/vue3-marquee-4.0.0-beta.0.tgz#aef5be722da8d03011875ceb3edb3a38b924d29a"
+  integrity sha512-j74A0F9l7Cj92C7w0nNkKB1CiuSWwojgwGwsUV7Jcrl/rccJpgZYFLuh9e5ZxHZUkH803UCStO5ajZVxBRyAug==
 
 vue@^3.3.4:
   version "3.3.4"

--- a/packages/playground/vite-project/src/main.ts
+++ b/packages/playground/vite-project/src/main.ts
@@ -1,8 +1,6 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 
-import 'vue3-marquee/dist/style.css'
 import Vue3Marquee from 'vue3-marquee'
 
 createApp(App).use(Vue3Marquee).mount('#app')
-// createApp(App).mount('#app')

--- a/packages/vue3-marquee/README.md
+++ b/packages/vue3-marquee/README.md
@@ -8,6 +8,10 @@ A simple marquee component with ZERO dependencies for Vue 3. This component was 
 
 View the live demos here: [https://vue3-marquee.vercel.app/examples](https://vue3-marquee.vercel.app/examples)
 
+## Upgrade to v4.x
+
+If you are using version 3.x of `vue3-marquee` you should upgrade to version 4.x. You can do this by running the [Installation and Usage](#installation-and-usage) command below. This add better support for Typescript. There is also a change with the `dist/style.css` import (it's been removed) so take a look at the [new documentation](https://vue3-marquee.vercel.app/introduction/v4) for instructions on how to migrate to this package.
+
 ## Installation and Usage
 
 ### Vue 3
@@ -32,7 +36,6 @@ The most common use case is to register the component globally.
 // main.js
 import { createApp } from 'vue'
 import Vue3Marquee from 'vue3-marquee'
-import 'vue3-marquee/dist/style.css'
 
 createApp(App).use(Vue3Marquee).mount('#app')
 ```
@@ -49,7 +52,6 @@ Alternatively you can also import the component locally.
 
 ```js
 import { Vue3Marquee } from 'vue3-marquee'
-import 'vue3-marquee/dist/style.css'
 
 export default {
   components: {
@@ -71,7 +73,6 @@ You can then use the component in your template
 
 <script>
 import { Vue3Marquee } from 'vue3-marquee'
-import 'vue3-marquee/dist/style.css'
 
 export default {
   components: {
@@ -108,12 +109,6 @@ export default defineNuxtPlugin((nuxtApp) => {
 ```
 
 This should register as a global component that you can call anywhere in your app under the `<Vue3Marquee>` tag.
-
-- Import the css file required by the component into your **`app.vue`** file.
-
-```js
-import 'vue3-marquee/dist/style.css'
-```
 
 ## Props and options
 

--- a/packages/vue3-marquee/package.json
+++ b/packages/vue3-marquee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue3-marquee",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0",
   "license": "MIT",
   "description": "A simple marquee component with ZERO dependencies for Vue 3",
   "author": "Sanjay Soundarajan <info@sanjaysoundarajan.dev> (https://sanjaysoundarajan.dev)",

--- a/packages/vue3-marquee/package.json
+++ b/packages/vue3-marquee/package.json
@@ -1,23 +1,23 @@
 {
   "name": "vue3-marquee",
-  "version": "3.2.1",
+  "version": "4.0.0-beta.0",
   "license": "MIT",
   "description": "A simple marquee component with ZERO dependencies for Vue 3",
   "author": "Sanjay Soundarajan <info@sanjaysoundarajan.dev> (https://sanjaysoundarajan.dev)",
+  "type": "module",
   "scripts": {
-    "dev": "vue-cli-service serve dev/serve.ts",
-    "build": "vite build && tsc -d --emitDeclarationOnly && vue-typegen gen -s ./src -o ./dist",
+    "dev": "vite build --watch",
+    "build": "vite build",
+    "dev:build": "vite build && tsc -d --emitDeclarationOnly && vue-typegen gen -s ./src -o ./dist",
     "prepublishOnly": "npm run build",
     "lint": "eslint \"{packages,playground}/**/*.{ts,tsx,vue,js,jsx,html}\"",
     "prettier": "npx prettier --write ."
   },
-  "dependencies": {},
   "peerDependencies": {
     "vue": "^3.2"
   },
   "files": [
-    "dist",
-    "dist/*.css"
+    "dist/*"
   ],
   "repository": {
     "type": "git",
@@ -27,13 +27,14 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "main": "dist/vue3-marquee.umd.js",
+  "main": "dist/vue3-marquee.cjs.js",
   "module": "dist/vue3-marquee.es.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/vue3-marquee.es.js",
-      "require": "./dist/vue3-marquee.umd.js"
+      "require": "./dist/vue3-marquee.cjs.js"
     },
     "./dist/style.css": "./dist/style.css"
   },
@@ -41,8 +42,12 @@
     "@babel/types": "7.22.5",
     "@types/node": "18.16.18",
     "@vitejs/plugin-vue": "2.3.4",
+    "@vue/compiler-sfc": "^3.3.4",
     "typescript": "5.0.4",
     "vite": "2.9.16",
+    "vite-plugin-css-injected-by-js": "^3.1.2",
+    "vite-plugin-dts": "^3.0.0-beta.3",
+    "vite-plugin-vue-type-imports": "^0.2.4",
     "vue": "3.3.4",
     "vue-tsc": "0.40.13",
     "vue-typegen": "0.2.0"

--- a/packages/vue3-marquee/src/global-shim.d.ts
+++ b/packages/vue3-marquee/src/global-shim.d.ts
@@ -1,1 +1,0 @@
-declare const VERSION: string

--- a/packages/vue3-marquee/src/index.ts
+++ b/packages/vue3-marquee/src/index.ts
@@ -1,24 +1,16 @@
-import { App } from 'vue'
+import type { App, Plugin } from 'vue'
 import Vue3Marquee from './vue3-marquee.vue'
+export * from './types'
+
+export interface PluginOptions {
+  name?: string
+}
+
+export default {
+  install(app: App, options?: PluginOptions) {
+    const name = options?.name ?? 'Vue3Marquee'
+    app.component(name, Vue3Marquee)
+  },
+} as Plugin
 
 export { Vue3Marquee }
-
-export function install(app: App, options: { name: string }) {
-  const finalOptions = Object.assign(
-    {},
-    {
-      name: 'Vue3Marquee',
-    },
-    options,
-  )
-
-  app.component(`${finalOptions.name}`, Vue3Marquee)
-}
-
-const plugin = {
-  // eslint-disable-next-line no-undef
-  version: VERSION,
-  install,
-}
-
-export default plugin

--- a/packages/vue3-marquee/src/types.ts
+++ b/packages/vue3-marquee/src/types.ts
@@ -1,0 +1,14 @@
+export interface MarqueeProps {
+  vertical: boolean
+  direction: 'normal' | 'reverse'
+  duration: number
+  delay: number
+  loop: number
+  clone: boolean
+  gradient: boolean
+  gradientColor: any
+  gradientWidth: string
+  gradientLength: string
+  pauseOnHover: boolean
+  pauseOnClick: boolean
+}

--- a/packages/vue3-marquee/src/vue-shim.d.ts
+++ b/packages/vue3-marquee/src/vue-shim.d.ts
@@ -1,5 +1,0 @@
-/* eslint-disable */
-declare module '*.vue' {
-  const component: any
-  export default component
-}

--- a/packages/vue3-marquee/tsconfig.json
+++ b/packages/vue3-marquee/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
-    "target": "ES2018",
+    "target": "ESNext",
     "module": "ESNext",
     "strict": true,
     "declaration": true,
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": ["es2017", "ESNext", "DOM", "DOM.Iterable"],
     "jsx": "preserve",
     "outDir": "dist",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "types": ["vite/client"]
   },
-  "include": ["src/**/*.ts", "src/**/*.vue"],
-  "exclude": ["node_modules", "dist", "**/*.js"]
+  "include": ["src", "*.d.ts"],
 }

--- a/packages/vue3-marquee/vite.config.ts
+++ b/packages/vue3-marquee/vite.config.ts
@@ -1,13 +1,26 @@
-import { resolve } from 'path'
+import { resolve } from 'node:path'
 import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
+import Vue from '@vitejs/plugin-vue'
+import VueTypeImports from 'vite-plugin-vue-type-imports'
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+import dts from 'vite-plugin-dts'
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [
+    Vue(),
+    VueTypeImports(),
+    cssInjectedByJsPlugin(),
+    dts({
+      insertTypesEntry: true,
+      copyDtsFiles: false,
+      cleanVueFileName: true,
+    }),
+  ],
   build: {
     lib: {
       entry: resolve(__dirname, './src/index.ts'),
-      name: 'vue3-marquee',
+      name: 'vue3marquee',
+      formats: ['es', 'cjs'],
     },
     outDir: 'dist',
     rollupOptions: {
@@ -19,8 +32,5 @@ export default defineConfig({
         },
       },
     },
-  },
-  define: {
-    VERSION: JSON.stringify(require('./package.json').version),
   },
 })

--- a/packages/vue3-marquee/vue-shim.d.ts
+++ b/packages/vue3-marquee/vue-shim.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+  import type { ComponentOptions } from 'vue'
+  const component: ComponentOptions
+  export default component
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,12 @@ importers:
       '@babel/types': 7.22.5
       '@types/node': 18.16.18
       '@vitejs/plugin-vue': 2.3.4
+      '@vue/compiler-sfc': ^3.3.4
       typescript: 5.0.4
       vite: 2.9.16
+      vite-plugin-css-injected-by-js: ^3.1.2
+      vite-plugin-dts: ^3.0.0-beta.3
+      vite-plugin-vue-type-imports: ^0.2.4
       vue: 3.3.4
       vue-tsc: 0.40.13
       vue-typegen: 0.2.0
@@ -39,8 +43,12 @@ importers:
       '@babel/types': 7.22.5
       '@types/node': 18.16.18
       '@vitejs/plugin-vue': 2.3.4_vite@2.9.16+vue@3.3.4
+      '@vue/compiler-sfc': 3.3.4
       typescript: 5.0.4
       vite: 2.9.16
+      vite-plugin-css-injected-by-js: 3.1.2_vite@2.9.16
+      vite-plugin-dts: 3.0.0-beta.3_e5096deb022bb453f8c88fc7e136a794
+      vite-plugin-vue-type-imports: 0.2.4_vite@2.9.16+vue@3.3.4
       vue: 3.3.4
       vue-tsc: 0.40.13_typescript@5.0.4
       vue-typegen: 0.2.0_typescript@5.0.4
@@ -73,6 +81,49 @@ packages:
   /@jridgewell/sourcemap-codec/1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
+  /@microsoft/api-extractor-model/7.27.3_@types+node@18.16.18:
+    resolution: {integrity: sha512-fSFvw7otYHduOkyshjTbapKKgwF8bgquVHvgF8VgeKtMYvqXkoaj7W6VcM7PNY7E2bbblhUgC4XNdqZLD4SJGw==}
+    dependencies:
+      '@microsoft/tsdoc': 0.14.2
+      '@microsoft/tsdoc-config': 0.16.2
+      '@rushstack/node-core-library': 3.59.4_@types+node@18.16.18
+    transitivePeerDependencies:
+      - '@types/node'
+    dev: true
+
+  /@microsoft/api-extractor/7.36.0_@types+node@18.16.18:
+    resolution: {integrity: sha512-P+kYgJFDXIr+UNzhRMhlpM/dderi6ab4lxn35vdhfAIMPtGCSXIJxrrtpTOQmQW8CZtmoZX06LYoUsKCc1zjow==}
+    hasBin: true
+    dependencies:
+      '@microsoft/api-extractor-model': 7.27.3_@types+node@18.16.18
+      '@microsoft/tsdoc': 0.14.2
+      '@microsoft/tsdoc-config': 0.16.2
+      '@rushstack/node-core-library': 3.59.4_@types+node@18.16.18
+      '@rushstack/rig-package': 0.4.0
+      '@rushstack/ts-command-line': 4.15.1
+      colors: 1.2.5
+      lodash: 4.17.21
+      resolve: 1.22.2
+      semver: 7.3.7
+      source-map: 0.6.1
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - '@types/node'
+    dev: true
+
+  /@microsoft/tsdoc-config/0.16.2:
+    resolution: {integrity: sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==}
+    dependencies:
+      '@microsoft/tsdoc': 0.14.2
+      ajv: 6.12.6
+      jju: 1.4.0
+      resolve: 1.19.0
+    dev: true
+
+  /@microsoft/tsdoc/0.14.2:
+    resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
+    dev: true
+
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -92,6 +143,63 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
+    dev: true
+
+  /@rollup/pluginutils/5.0.2_rollup@2.67.3:
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.1
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 2.67.3
+    dev: true
+
+  /@rushstack/node-core-library/3.59.4_@types+node@18.16.18:
+    resolution: {integrity: sha512-YAKJDC6Mz/KA1D7bvB88WaRX3knt/ZuLzkRu5G9QADGSjLtvTWzCNCytRF2PCSaaHOZaZsWul4F1KQdgFgUDqA==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+    dependencies:
+      '@types/node': 18.16.18
+      colors: 1.2.5
+      fs-extra: 7.0.1
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.2
+      semver: 7.3.7
+      z-schema: 5.0.5
+    dev: true
+
+  /@rushstack/rig-package/0.4.0:
+    resolution: {integrity: sha512-FnM1TQLJYwSiurP6aYSnansprK5l8WUK8VG38CmAaZs29ZeL1msjK0AP1VS4ejD33G0kE/2cpsPsS9jDenBMxw==}
+    dependencies:
+      resolve: 1.22.2
+      strip-json-comments: 3.1.1
+    dev: true
+
+  /@rushstack/ts-command-line/4.15.1:
+    resolution: {integrity: sha512-EL4jxZe5fhb1uVL/P/wQO+Z8Rc8FMiWJ1G7VgnPDvdIt5GVjRfK7vwzder1CZQiX3x0PY6uxENYLNGTFd1InRQ==}
+    dependencies:
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      colors: 1.2.5
+      string-argv: 0.3.2
+    dev: true
+
+  /@types/argparse/1.0.38:
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+    dev: true
+
+  /@types/estree/1.0.1:
+    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: true
 
   /@types/node/18.16.18:
@@ -115,16 +223,34 @@ packages:
       '@volar/source-map': 0.40.13
     dev: true
 
+  /@volar/language-core/1.7.10:
+    resolution: {integrity: sha512-18Gmth5M0UI3hDDqhZngjMnb6WCslcfglkOdepRIhGxRYe7xR7DRRzciisYDMZsvOQxDYme+uaohg0dKUxLV2Q==}
+    dependencies:
+      '@volar/source-map': 1.7.10
+    dev: true
+
   /@volar/source-map/0.40.13:
     resolution: {integrity: sha512-dbdkAB2Nxb0wLjAY5O64o3ywVWlAGONnBIoKAkXSf6qkGZM+nJxcizsoiI66K+RHQG0XqlyvjDizfnTxr+6PWg==}
     dependencies:
       '@vue/reactivity': 3.2.38
     dev: true
 
+  /@volar/source-map/1.7.10:
+    resolution: {integrity: sha512-FBpLEOKJpRxeh2nYbw1mTI5sZOPXYU8LlsCz6xuBY3yNtAizDTTIZtBHe1V8BaMpoSMgRysZe4gVxMEi3rDGVA==}
+    dependencies:
+      muggle-string: 0.3.1
+    dev: true
+
   /@volar/typescript-faster/0.40.13:
     resolution: {integrity: sha512-uy+TlcFkKoNlKEnxA4x5acxdxLyVDIXGSc8cYDNXpPKjBKXrQaetzCzlO3kVBqu1VLMxKNGJMTKn35mo+ILQmw==}
     dependencies:
       semver: 7.3.7
+    dev: true
+
+  /@volar/typescript/1.7.10:
+    resolution: {integrity: sha512-yqIov4wndLU3GE1iE25bU5W6T+P+exPePcE1dFPPBKzQIBki1KvmdQN5jBlJp3Wo+wp7UIxa/RsdNkXT+iFBjg==}
+    dependencies:
+      '@volar/language-core': 1.7.10
     dev: true
 
   /@volar/vue-language-core/0.40.13:
@@ -190,6 +316,25 @@ packages:
       '@vue/compiler-dom': 3.3.4
       '@vue/shared': 3.3.4
 
+  /@vue/language-core/1.8.3_typescript@5.0.4:
+    resolution: {integrity: sha512-AzhvMYoQkK/tg8CpAAttO19kx1zjS3+weYIr2AhlH/M5HebVzfftQoq4jZNFifjq+hyLKi8j9FiDMS8oqA89+A==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@volar/language-core': 1.7.10
+      '@volar/source-map': 1.7.10
+      '@vue/compiler-dom': 3.3.4
+      '@vue/reactivity': 3.3.4
+      '@vue/shared': 3.3.4
+      minimatch: 9.0.2
+      muggle-string: 0.3.1
+      typescript: 5.0.4
+      vue-template-compiler: 2.7.14
+    dev: true
+
   /@vue/reactivity-transform/3.3.4:
     resolution: {integrity: sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==}
     dependencies:
@@ -249,6 +394,40 @@ packages:
   /@vue/shared/3.3.4:
     resolution: {integrity: sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==}
 
+  /@vue/typescript/1.8.3_typescript@5.0.4:
+    resolution: {integrity: sha512-6bdgSnIFpRYHlt70pHmnmNksPU00bfXgqAISeaNz3W6d2cH0OTfH8h/IhligQ82sJIhsuyfftQJ5518ZuKIhtA==}
+    dependencies:
+      '@volar/typescript': 1.7.10
+      '@vue/language-core': 1.8.3_typescript@5.0.4
+    transitivePeerDependencies:
+      - typescript
+    dev: true
+
+  /ajv/6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+    dev: true
+
+  /argparse/1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    dependencies:
+      sprintf-js: 1.0.3
+    dev: true
+
+  /balanced-match/1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
+
+  /brace-expansion/2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: true
+
   /braces/3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
@@ -256,8 +435,36 @@ packages:
       fill-range: 7.0.1
     dev: true
 
+  /colors/1.2.5:
+    resolution: {integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==}
+    engines: {node: '>=0.1.90'}
+    dev: true
+
+  /commander/9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /csstype/3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
+
+  /de-indent/1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
+    dev: true
+
+  /debug/4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: true
 
   /esbuild-android-64/0.14.39:
     resolution: {integrity: sha512-EJOu04p9WgZk0UoKTqLId9VnIsotmI/Z98EXrKURGb3LPNunkeffqQIkjS2cAvidh+OK5uVrXaIP229zK6GvhQ==}
@@ -470,6 +677,10 @@ packages:
   /estree-walker/2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  /fast-deep-equal/3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
+
   /fast-glob/3.2.11:
     resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
     engines: {node: '>=8.6.0'}
@@ -479,6 +690,21 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.4
+    dev: true
+
+  /fast-glob/3.2.12:
+    resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.4
+    dev: true
+
+  /fast-json-stable-stringify/2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: true
 
   /fastq/1.13.0:
@@ -501,6 +727,15 @@ packages:
       graceful-fs: 4.2.9
       jsonfile: 6.1.0
       universalify: 2.0.0
+    dev: true
+
+  /fs-extra/7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+    dependencies:
+      graceful-fs: 4.2.9
+      jsonfile: 4.0.0
+      universalify: 0.1.2
     dev: true
 
   /fsevents/2.3.2:
@@ -533,6 +768,22 @@ packages:
       function-bind: 1.1.1
     dev: true
 
+  /he/1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+    dev: true
+
+  /import-lazy/4.0.0:
+    resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /is-core-module/2.12.1:
+    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
+    dependencies:
+      has: 1.0.3
+    dev: true
+
   /is-core-module/2.8.1:
     resolution: {integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==}
     dependencies:
@@ -556,6 +807,20 @@ packages:
     engines: {node: '>=0.12.0'}
     dev: true
 
+  /jju/1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+    dev: true
+
+  /json-schema-traverse/0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    dev: true
+
+  /jsonfile/4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+    optionalDependencies:
+      graceful-fs: 4.2.9
+    dev: true
+
   /jsonfile/6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
     dependencies:
@@ -564,11 +829,39 @@ packages:
       graceful-fs: 4.2.9
     dev: true
 
+  /kolorist/1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+    dev: true
+
+  /local-pkg/0.4.3:
+    resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
+    engines: {node: '>=14'}
+    dev: true
+
+  /lodash.get/4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    dev: true
+
+  /lodash.isequal/4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    dev: true
+
+  /lodash/4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
+
   /lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
+
+  /magic-string/0.26.7:
+    resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
+    engines: {node: '>=12'}
+    dependencies:
+      sourcemap-codec: 1.4.8
     dev: true
 
   /magic-string/0.30.0:
@@ -590,9 +883,24 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /minimatch/9.0.2:
+    resolution: {integrity: sha512-PZOT9g5v2ojiTL7r1xF6plNHLtOeTpSlDI007As2NlA2aYBMfVom17yqa6QzhmDP8QOhn7LjHTg7DFCVSSa6yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /mri/1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+    dev: true
+
+  /ms/2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: true
+
+  /muggle-string/0.3.1:
+    resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}
     dev: true
 
   /nanoid/3.3.4:
@@ -630,8 +938,20 @@ packages:
     hasBin: true
     dev: false
 
+  /punycode/2.3.0:
+    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
+    engines: {node: '>=6'}
+    dev: true
+
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: true
+
+  /resolve/1.19.0:
+    resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
+    dependencies:
+      is-core-module: 2.12.1
+      path-parse: 1.0.7
     dev: true
 
   /resolve/1.22.0:
@@ -639,6 +959,15 @@ packages:
     hasBin: true
     dependencies:
       is-core-module: 2.8.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
+  /resolve/1.22.2:
+    resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.12.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -677,6 +1006,14 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
+  /semver/7.5.3:
+    resolution: {integrity: sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
@@ -684,6 +1021,25 @@ packages:
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
+    dev: true
+
+  /sprintf-js/1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: true
+
+  /string-argv/0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+    dev: true
+
+  /strip-json-comments/3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
     dev: true
 
   /supports-preserve-symlinks-flag/1.0.0:
@@ -714,9 +1070,77 @@ packages:
     hasBin: true
     dev: true
 
+  /universalify/0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+    dev: true
+
   /universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
+    dev: true
+
+  /uri-js/4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    dependencies:
+      punycode: 2.3.0
+    dev: true
+
+  /validator/13.9.0:
+    resolution: {integrity: sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==}
+    engines: {node: '>= 0.10'}
+    dev: true
+
+  /vite-plugin-css-injected-by-js/3.1.2_vite@2.9.16:
+    resolution: {integrity: sha512-hv/DKA1Yn7Dcqh51nSDiqXJORzXxky4I1CjzsSbJtap0lgCk8qVzkoyEIgWMu+XXjEzv1tyIsLHYwobHTLLh/w==}
+    peerDependencies:
+      vite: '>2.0.0-0'
+    dependencies:
+      vite: 2.9.16
+    dev: true
+
+  /vite-plugin-dts/3.0.0-beta.3_e5096deb022bb453f8c88fc7e136a794:
+    resolution: {integrity: sha512-01cyoNH4811NW1ITde+RDvkU4w7EBap54/Rj0CDb7Ayu0SfwPy5OvJtR2NZZA2fqnXDX9y5NeaS1hzzHpJ2tVQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    dependencies:
+      '@microsoft/api-extractor': 7.36.0_@types+node@18.16.18
+      '@rollup/pluginutils': 5.0.2_rollup@2.67.3
+      '@rushstack/node-core-library': 3.59.4_@types+node@18.16.18
+      '@vue/language-core': 1.8.3_typescript@5.0.4
+      debug: 4.3.4
+      kolorist: 1.8.0
+      typescript: 5.0.4
+      vue-tsc: 1.8.3_typescript@5.0.4
+    optionalDependencies:
+      rollup: 2.67.3
+      vite: 2.9.16
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - supports-color
+    dev: true
+
+  /vite-plugin-vue-type-imports/0.2.4_vite@2.9.16+vue@3.3.4:
+    resolution: {integrity: sha512-qjz1RMd1MgG1gd2KNGo2uDSpGbaB7KwcuUVFZfC8mBdzUG63eR/gJzMUvfpM9JWQ+JTEfEGiLxe6NJvg4n3Kuw==}
+    peerDependencies:
+      vite: ^3.0.0
+      vue: ^2.7.0 || ^3.2.24
+    dependencies:
+      '@babel/types': 7.22.5
+      '@vue/compiler-sfc': 3.3.4
+      debug: 4.3.4
+      fast-glob: 3.2.12
+      local-pkg: 0.4.3
+      magic-string: 0.26.7
+      picocolors: 1.0.0
+      vite: 2.9.16
+      vue: 3.3.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /vite/2.9.16:
@@ -743,6 +1167,13 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /vue-template-compiler/2.7.14:
+    resolution: {integrity: sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==}
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+    dev: true
+
   /vue-tsc/0.40.13_typescript@5.0.4:
     resolution: {integrity: sha512-xzuN3g5PnKfJcNrLv4+mAjteMd5wLm5fRhW0034OfNJZY4WhB07vhngea/XeGn7wNYt16r7syonzvW/54dcNiA==}
     hasBin: true
@@ -763,6 +1194,18 @@ packages:
       '@volar/vue-language-core': 0.40.13
       '@volar/vue-typescript': 0.40.13
       typescript: 5.1.3
+    dev: true
+
+  /vue-tsc/1.8.3_typescript@5.0.4:
+    resolution: {integrity: sha512-Ua4DHuYxjudlhCW2nRZtaXbhIDVncRGIbDjZhHpF8Z8vklct/G/35/kAPuGNSOmq0JcvhPAe28Oa7LWaUerZVA==}
+    hasBin: true
+    peerDependencies:
+      typescript: '*'
+    dependencies:
+      '@vue/language-core': 1.8.3_typescript@5.0.4
+      '@vue/typescript': 1.8.3_typescript@5.0.4
+      semver: 7.5.3
+      typescript: 5.0.4
     dev: true
 
   /vue-typegen/0.2.0_typescript@5.0.4:
@@ -790,4 +1233,16 @@ packages:
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true
+
+  /z-schema/5.0.5:
+    resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      lodash.get: 4.4.2
+      lodash.isequal: 4.5.0
+      validator: 13.9.0
+    optionalDependencies:
+      commander: 9.5.0
     dev: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'packages/**'
+  - 'packages/playground'


### PR DESCRIPTION
This PR should change how the package is built. Types are also now more accurate and friendly for developers.

BREAKING: The dist/style.css file is no longer included in the package. This means that you can remove that import from your projects as well.

