### PR TITLE
fix:  events emitted on overflow detected/cleared

### DIFF
--- a/packages/vue3-marquee/src/vue3-marquee.vue
+++ b/packages/vue3-marquee/src/vue3-marquee.vue
@@ -241,10 +241,10 @@ export default defineComponent({
             if (props.animateOnOverflowOnly) {
               if (contentWidth.value < containerWidth.value) {
                 animateOnOverflowPause.value = true
-                emit('onOverflowDetected')
+                emit('onOverflowCleared')
               } else {
                 animateOnOverflowPause.value = false
-                emit('onOverflowCleared')
+                emit('onOverflowDetected')
               }
 
               return 0 // don't clone if animateOnOverflowOnly is true


### PR DESCRIPTION
Hey! It seems the `onOverflowDetected` and `onOverflowCleared` are swapped. Currently, when the animation is running due to overflow, the `onOverflowCleared` is emitted.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the event emission logic for overflow detection and clearance by swapping the 'onOverflowDetected' and 'onOverflowCleared' events to ensure they are emitted under the correct conditions.

Bug Fixes:
- Correct the emission of events by swapping 'onOverflowDetected' and 'onOverflowCleared' to their appropriate conditions.

<!-- Generated by sourcery-ai[bot]: end summary -->