### PR TITLE
🐛 fix: check contianer width. closes #350

### DIFF
--- a/packages/playground/nuxt-project/app.vue
+++ b/packages/playground/nuxt-project/app.vue
@@ -97,7 +97,7 @@
       </Vue3Marquee>
     </div>
 
-    <div>
+    <div v-if="showAll">
       <p>Animate on Overflow</p>
 
       <Vue3Marquee :animateOnOverflowOnly="true" class="">
@@ -111,6 +111,25 @@
       <div style="height: 200px; width: max-content">
         <Vue3Marquee :vertical="true" :pause="playState">
           <img v-for="i in img_30" :key="i" height="50" :src="i" />
+        </Vue3Marquee>
+      </div>
+    </div>
+
+    <div>
+      <p>
+        Fix for issue:
+        <a
+          href="https://github.com/megasanjay/vue3-marquee/issues/350"
+          target="__blank"
+          >vue3-marquee#350</a
+        >
+      </p>
+
+      <button @click="toggleShow = !toggleShow">Toggle</button>
+
+      <div v-if="toggleShow" style="height: 80px">
+        <Vue3Marquee :animateOnOverflowOnly="true">
+          <img v-for="i in img_5" :key="i" height="80" :src="i" />
         </Vue3Marquee>
       </div>
     </div>
@@ -193,6 +212,7 @@ export default defineComponent({
       img_5: this.getImgURLS(5),
       playState: false,
       showAll: false,
+      toggleShow: true,
     }
   },
   methods: {

--- a/packages/playground/vite-project/src/App.vue
+++ b/packages/playground/vite-project/src/App.vue
@@ -119,6 +119,25 @@
       <p>
         Fix for issue:
         <a
+          href="https://github.com/megasanjay/vue3-marquee/issues/350"
+          target="__blank"
+          >vue3-marquee#350</a
+        >
+      </p>
+
+      <button @click="toggleShow = !toggleShow">Toggle</button>
+
+      <div v-show="toggleShow" style="height: 135px">
+        <Vue3Marquee :animateOnOverflowOnly="true" class="">
+          <img v-for="i in img_5" :key="i" height="80" :src="i" />
+        </Vue3Marquee>
+      </div>
+    </div>
+
+    <div v-if="showAll">
+      <p>
+        Fix for issue:
+        <a
           href="https://github.com/megasanjay/vue3-marquee/issues/295"
           target="__blank"
           >vue3-marquee#295</a
@@ -210,6 +229,7 @@ export default defineComponent({
       img_5: this.getImgURLS(5),
       playState: false,
       showAll: false,
+      toggleShow: true,
     }
   },
   methods: {

--- a/packages/playground/vite-project/src/App.vue
+++ b/packages/playground/vite-project/src/App.vue
@@ -127,8 +127,8 @@
 
       <button @click="toggleShow = !toggleShow">Toggle</button>
 
-      <div v-show="toggleShow" style="height: 135px">
-        <Vue3Marquee :animateOnOverflowOnly="true" class="">
+      <div v-if="toggleShow" style="height: 80px">
+        <Vue3Marquee :animateOnOverflowOnly="true">
           <img v-for="i in img_5" :key="i" height="80" :src="i" />
         </Vue3Marquee>
       </div>

--- a/packages/vue3-marquee/package.json
+++ b/packages/vue3-marquee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue3-marquee",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "license": "MIT",
   "description": "A simple marquee component with ZERO dependencies for Vue 3",
   "author": "Sanjay Soundarajan <info@sanjaysoundarajan.dev> (https://sanjaysoundarajan.dev)",

--- a/packages/vue3-marquee/src/vue3-marquee.vue
+++ b/packages/vue3-marquee/src/vue3-marquee.vue
@@ -34,6 +34,7 @@
         !animateOnOverflowOnly ||
         (animateOnOverflowOnly && !animateOnOverflowPause)
       "
+      style="background-color: green !important"
     >
       <slot></slot>
     </div>
@@ -167,7 +168,10 @@ export default defineComponent({
 
     const verticalAnimationPause = ref(false)
 
-    const animateOnOverflowPause = ref(false) // state to pause the animation when animateOnOverflowOnly is true
+    const animateOnOverflowPause = ref(
+      props.animateOnOverflowOnly ? true : false,
+    )
+    const animateOnOverflowCalculated = ref(false)
 
     const containerWidth = ref(0)
     const contentWidth = ref(0)
@@ -222,7 +226,9 @@ export default defineComponent({
               containerHeight.value / contentHeight.value,
             )
 
-            cloneAmount.value = isFinite(localCloneAmount)
+            cloneAmount.value = props.animateOnOverflowOnly
+              ? 0
+              : isFinite(localCloneAmount)
               ? localCloneAmount
               : 0
 
@@ -492,6 +498,7 @@ export default defineComponent({
       minWidth,
       minHeight,
       animateOnOverflowPause,
+      animateOnOverflowCalculated,
       marqueeContent,
       marqueeOverlayContainer,
       componentKey,

--- a/packages/vue3-marquee/src/vue3-marquee.vue
+++ b/packages/vue3-marquee/src/vue3-marquee.vue
@@ -34,7 +34,6 @@
         !animateOnOverflowOnly ||
         (animateOnOverflowOnly && !animateOnOverflowPause)
       "
-      style="background-color: green !important"
     >
       <slot></slot>
     </div>
@@ -168,10 +167,7 @@ export default defineComponent({
 
     const verticalAnimationPause = ref(false)
 
-    const animateOnOverflowPause = ref(
-      props.animateOnOverflowOnly ? true : false,
-    )
-    const animateOnOverflowCalculated = ref(false)
+    const animateOnOverflowPause = ref(true)
 
     const containerWidth = ref(0)
     const contentWidth = ref(0)
@@ -244,8 +240,8 @@ export default defineComponent({
             contentWidth.value = marqueeContent.value.clientWidth
             containerWidth.value = marqueeOverlayContainer.value.clientWidth
 
-            if (props.animateOnOverflowOnly) {
-              if (contentWidth.value < containerWidth.value) {
+            if (props.animateOnOverflowOnly && ready.value) {
+              if (contentWidth.value <= containerWidth.value) {
                 animateOnOverflowPause.value = true
                 emit('onOverflowCleared')
               } else {
@@ -498,7 +494,6 @@ export default defineComponent({
       minWidth,
       minHeight,
       animateOnOverflowPause,
-      animateOnOverflowCalculated,
       marqueeContent,
       marqueeOverlayContainer,
       componentKey,


### PR DESCRIPTION
Replace `<` with a `<=` 😭

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the overflow condition in the vue3-marquee component by changing the comparison operator to handle cases where content width is equal to container width. Enhance the playground applications by adding a toggle button to control the visibility of a marquee component.

Bug Fixes:
- Fix the condition to check if content width is less than or equal to container width to correctly handle overflow scenarios.

Enhancements:
- Add a toggle button to control the display of a marquee component in the playground applications.

<!-- Generated by sourcery-ai[bot]: end summary -->