### PR TITLE
fix: reverse is not doing great in Arabic

### DIFF
--- a/packages/playground/vite-project/src/App.vue
+++ b/packages/playground/vite-project/src/App.vue
@@ -151,6 +151,7 @@
           :duration="5"
           animate-on-overflow-only
           pause-on-hover
+          pause-on-click
         >
           <span
             v-for="(item, index) in arabicList"

--- a/packages/playground/vite-project/src/App.vue
+++ b/packages/playground/vite-project/src/App.vue
@@ -145,10 +145,23 @@
       </p>
 
       <div style="display: flex">
-        <Vue3Marquee :duration="7" direction="reverse">
-          نفس إحكام الإنذار، لم, فبعد وحل الأثنان. هو تصفح بالرّغم مك|هو
+        <Vue3Marquee
+          :direction="isRTL ? 'reverse' : 'normal'"
+          :delay="2"
+          :duration="5"
+          animate-on-overflow-only
+          pause-on-hover
+        >
+          <span
+            v-for="(item, index) in arabicList"
+            :key="index"
+            :style="isRTL ? 'margin-left: 48px' : 'margin-right: 48px'"
+          >
+            {{ `${index + 1}. ${item}` }}
+          </span>
         </Vue3Marquee>
       </div>
+      <button @click="handleToggleDirection">Toggle text direction</button>
     </div>
 
     <div v-if="showAll">
@@ -230,9 +243,20 @@ export default defineComponent({
       playState: false,
       showAll: false,
       toggleShow: true,
+      isRTL: false,
+      arabicList: ['علوم الفضاء والتكنولوجيا', 'المهمات الفضائية', 'أكاديمية الفضاء الوطنية', 'تنظيم الفضاء', 'البرامج الفضائية'],
     }
   },
   methods: {
+    handleToggleDirection() {
+      const _documentElement = document.documentElement
+      const dir = _documentElement.getAttribute('dir')
+
+      const _isRTL = dir === 'rtl'
+
+      _isRTL ? _documentElement.removeAttribute('dir') : _documentElement.setAttribute('dir', 'rtl')
+      this.isRTL = !_isRTL
+    },
     generateRandomString() {
       const randomString = Math.random().toString(36).substring(2, 15)
       return `https://api.dicebear.com/7.x/adventurer/svg/seed=${randomString}`

--- a/packages/vue3-marquee/src/vue3-marquee.vue
+++ b/packages/vue3-marquee/src/vue3-marquee.vue
@@ -9,6 +9,8 @@
     @mouseleave="hoverEnded"
     @mousedown="mouseDown"
     @mouseup="mouseUp"
+    @touchstart="mouseDown"
+    @touchend="mouseUp"
   >
     <div
       class="transparent-overlay"
@@ -158,6 +160,8 @@ export default defineComponent({
   ],
 
   setup(props, { emit }) {
+    const isMobile = 'ontouchstart' in document.documentElement
+
     const cloneAmount = ref(0)
 
     const minWidth = ref('100%')
@@ -301,7 +305,7 @@ export default defineComponent({
     )
 
     const hoverStarted = () => {
-      if (props.pauseOnHover) {
+      if (!isMobile && props.pauseOnHover) {
         emit('onPause')
 
         mouseOverMarquee.value = true
@@ -309,7 +313,7 @@ export default defineComponent({
     }
 
     const hoverEnded = () => {
-      if (props.pauseOnHover) {
+      if (!isMobile && props.pauseOnHover) {
         emit('onResume')
 
         mouseOverMarquee.value = false

--- a/packages/vue3-marquee/src/vue3-marquee.vue
+++ b/packages/vue3-marquee/src/vue3-marquee.vue
@@ -513,6 +513,16 @@ export default defineComponent({
 </script>
 
 <style>
+:root {
+  --scroll-start: 0%;
+  --scroll-end: -100%;
+}
+
+html[dir='rtl'] {
+  --scroll-start: 100%;
+  --scroll-end: 0%;
+}
+
 .vue3-marquee {
   display: flex !important;
   position: relative;
@@ -565,10 +575,10 @@ export default defineComponent({
 
 @keyframes scrollX {
   0% {
-    transform: translateX(0%);
+    transform: translateX(var(--scroll-start));
   }
   100% {
-    transform: translateX(-100%);
+    transform: translateX(var(--scroll-end));
   }
 }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

> - fix #295

### 💡 Background and Solution

#### 1. Reverse is not doing great in Arabic
Typically Arabic web pages require a `dir` attribute on the `html` tags to indicate the direction of the text, which you were unable to reproduce when you originally tested in issue #295 because the `dir` attribute was not specified to set the direction of the text.

#### 2. Can't click pause on mobile device
Add `touchstart` and `touchend` events to support the click pause feature on mobile device.
Since the `mouseleave` event is unreliable on mobile, the `mouseenter` event is blocked on mobile device.

#### Before
![error](https://github.com/user-attachments/assets/e98b5377-6ec4-45a8-a74b-7f5fc823587b)

#### After
![reverse](https://github.com/user-attachments/assets/fbefaa36-0de8-4eaa-b67f-2967dc991b42)

### 📝 Change Log

> - Fixed Arabic display issue. closes #295
> - Fix the issue of not being able to click pause on mobile

## Summary by Sourcery

Fix text direction issues in RTL languages like Arabic, and improve pause functionality on mobile devices. Toggle the text direction by adding a `dir` attribute to the `html` element. Add `touchstart` and `touchend` event listeners to the marquee component to support pausing on click on mobile devices. Remove the `mouseenter` event listener on mobile devices to avoid blocking the marquee. Add a button to toggle the text direction between left-to-right and right-to-left.

Bug Fixes:
- Fix reversed text direction in right-to-left languages such as Arabic.
- Fix pause on click for mobile devices by adding touch event listeners and removing unreliable mouse listeners for mobile devices